### PR TITLE
revert: Revert attempt to use @tailwindcss/postcss

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^0.7.2",
     "@vitejs/plugin-vue": "^5.2.3",
     "vite": "^6.3.5"
   }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
This reverts the changes I made to address the Tailwind CSS PostCSS plugin error. My previous attempt involved adding "@tailwindcss/postcss" as a dependency and updating postcss.config.js. However, this led to an "npm install" failure as the specified version of "@tailwindcss/postcss" was not found.

This commit restores:
- frontend/package.json by removing the "@tailwindcss/postcss" dependency.
- frontend/postcss.config.js to use "tailwindcss: {}" directly.

This is to re-test the build with the standard Tailwind CSS v4 configuration, where Tailwind CSS itself is intended to be the PostCSS plugin. If the original PostCSS error ("plugin has moved") resurfaces, further investigation into the Vite/PostCSS/TailwindCSSv4 interaction will be needed.