### PR TITLE
fix: Update @tailwindcss/vite version to 'latest'

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^0.2.0",
+    "@tailwindcss/vite": "latest",
     "@vitejs/plugin-vue": "^5.2.3",
     "vite": "^6.3.5"
   }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,17 +9,9 @@ export default defineConfig({
     vue(),
     tailwindcssVite() // Add the plugin here
   ],
-import path from 'path' // Ensure path is imported
-
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [vue()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
   },
-  // If server options were previously defined, they'd need to be preserved.
-  // For this project, the server options are not explicitly set in vite.config.js,
-  // as CORS is handled by the backend and frontend is served via Nginx in Docker.
 })


### PR DESCRIPTION
I changed the version constraint for "@tailwindcss/vite" in frontend/package.json from "^0.2.0" to "latest". This is to resolve an "npm install" error (ETARGET - No matching version found) during the Docker build.

Using "latest" will instruct npm to fetch the most recent stable version of the plugin.