### PR TITLE
Fix: Correct template literal parsing in Vue components

### DIFF
--- a/frontend/src/components/ServiceCard.vue
+++ b/frontend/src/components/ServiceCard.vue
@@ -67,7 +67,7 @@ export default {
   methods: {
     getIconUrl(iconName) {
       // Assuming icons are in frontend/public/icons/
-      return \`/icons/\${iconName}\`;
+      return `/icons/${iconName}`;
     },
     normalizedUrl(url) {
       if (!url.startsWith('http://') && !url.startsWith('https://')) {

--- a/frontend/src/components/ServiceList.vue
+++ b/frontend/src/components/ServiceList.vue
@@ -114,7 +114,7 @@ export default {
         console.error('Failed to fetch service statuses:', err);
         this.error = err;
         if (err.response) {
-          this.error.message = err.response.data.message || \`Server error: \${err.response.status}\`;
+          this.error.message = err.response.data.message || `Server error: ${err.response.status}`;
         } else if (err.request) {
           this.error.message = 'No response from server. Is it running?';
         } else {

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -152,12 +152,13 @@ export default {
       try {
         if (serviceToEdit.value && serviceToEdit.value.id) {
           // Update existing service
-          const response = await adminApiClient.put(\`/services/\${serviceToEdit.value.id}\`, serviceData);
-          setGlobalMessage(\`Service '\${response.data.name}' updated successfully!\`, 'success');
+          const url = '/services/' + serviceToEdit.value.id;
+          const response = await adminApiClient.put(url, serviceData);
+          setGlobalMessage(`Service '${response.data.name}' updated successfully!`, 'success');
         } else {
           // Add new service
           const response = await adminApiClient.post('/services', serviceData);
-          setGlobalMessage(\`Service '\${response.data.name}' added successfully!\`, 'success');
+          setGlobalMessage(`Service '${response.data.name}' added successfully!`, 'success');
         }
         hideForm();
         await fetchServices(true); // Refresh list
@@ -171,11 +172,11 @@ export default {
     };
 
     const confirmDeleteService = async (service) => {
-      if (window.confirm(\`Are you sure you want to delete the service "\${service.name}"?\`)) {
+      if (window.confirm(`Are you sure you want to delete the service "${service.name}"?`)) {
         listLoading.value = true; // Use listLoading as it affects the table area
         try {
-          await adminApiClient.delete(\`/services/\${service.id}\`);
-          setGlobalMessage(\`Service '\${service.name}' deleted successfully.\`, 'success');
+          await adminApiClient.delete(`/services/${service.id}`);
+          setGlobalMessage(`Service '${service.name}' deleted successfully.`, 'success');
           await fetchServices(true); // Refresh list
         } catch (err) {
           console.error('Failed to delete service:', err);


### PR DESCRIPTION
Addresses a Docker build failure caused by errors during the Vite/Vue SFC compilation step. The build error indicated issues with Unicode escape sequences (often related to backslashes in strings) and was triggered by improper parsing of template literals in several .vue files, including AdminView.vue, ServiceList.vue, and ServiceCard.vue.

The initial fix involved changing one instance of a template literal to string concatenation in AdminView.vue. However, the build process revealed this was a more widespread issue. The final solution involved correcting the usage and escaping of template literals across the affected Vue components.

Additionally, I handled Docker environment issues such as installing docker-compose and resolving permissions.

The Docker build now completes successfully.