### PR TITLE
feat: Change default backend host port to 3002

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ HomeDash is a responsive, visually polished Start Page dashboard designed for ho
 
 4.  **Access HomeDash:**
     - Frontend (Main Application): [http://localhost:8080](http://localhost:8080)
-    - Backend API (if needed for direct access/testing): [http://localhost:3001](http://localhost:3001)
+    - Backend API (if needed for direct access/testing): [http://localhost:3002](http://localhost:3002)
 
 ## Default Admin Credentials
 
@@ -98,7 +98,7 @@ cd frontend
 npm install
 npm run dev
 \`\`\`
-The frontend development server will typically run on `http://localhost:5173` (Vite's default). Ensure the `FRONTEND_URL` in the backend's `.env` (or equivalent config) matches this for CORS during development. The frontend API calls currently point to `http://localhost:3001`.
+The frontend development server will typically run on `http://localhost:5173` (Vite's default). Ensure the `FRONTEND_URL` in the backend's `.env` (or equivalent config) matches this for CORS during development. Frontend API calls are directed to the URL specified in the \`VITE_API_BASE_URL\` environment variable. When running via Docker Compose, this is automatically set to \`http://localhost:3002/api\`. For local frontend development (e.g., using \`npm run dev\` in the \`frontend\` directory), you should create a \`.env\` file (e.g., \`frontend/.env.development\` or \`frontend/.env.local\`) in the \`frontend\` directory and set \`VITE_API_BASE_URL=http://localhost:3001/api\` to connect to a locally running backend (which typically runs on port 3001 as per \`backend/.env.example\`).
 
 ## HTTPS Support
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -87,7 +87,7 @@ async function checkServiceHealth(service) {
     if (error.code) { // Axios error code (e.g., ENOTFOUND, ECONNREFUSED)
         errorMessage = error.code;
     } else if (error.response && error.response.status) { // HTTP status from error response
-        errorMessage = \`Status \${error.response.status}\`;
+        errorMessage = `Status ${error.response.status}`;
     }
     return { ...service, status: 'down', error: errorMessage, lastChecked: new Date().toISOString() };
   }
@@ -233,12 +233,12 @@ async function startServer() {
     // console.log('Admin password hashed.'); // Keep console cleaner
 
     app.listen(PORT, () => {
-      console.log(\`Backend server is running on http://localhost:\${PORT}\`);
-      // console.log(\`Admin username: \${ADMIN_USERNAME}\`);
-      // console.log(\`Admin password (for local dev): \${ADMIN_PASSWORD}\`);
-      // console.log(\`Session secret (for local dev): \${SESSION_SECRET}\`);
+      console.log(`Backend server is running on http://localhost:${PORT}`);
+      // console.log(`Admin username: ${ADMIN_USERNAME}`);
+      // console.log(`Admin password (for local dev): ${ADMIN_PASSWORD}`);
+      // console.log(`Session secret (for local dev): ${SESSION_SECRET}`);
     });
-  } catch (error)
+  } catch (error) {
     console.error("Failed to hash admin password or start server:", error);
     process.exit(1);
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: homedash_backend
     restart: unless-stopped
     ports:
-      - "3001:3001" # Expose backend on host port 3001
+      - "3002:3001" # Expose backend on host port 3002
     environment:
       - NODE_ENV=production
       - PORT=3001
@@ -23,7 +23,7 @@ services:
     build:
       context: ./frontend
       args:
-        VITE_API_BASE_URL: /api
+        VITE_API_BASE_URL: http://localhost:3002/api
     container_name: homedash_frontend
     restart: unless-stopped
     ports:

--- a/frontend/src/components/ServiceList.vue
+++ b/frontend/src/components/ServiceList.vue
@@ -18,7 +18,7 @@
     </div>
     <div v-else-if="error" class="text-center py-10">
       <p class="text-lg text-red-500 dark:text-red-400">Error loading service statuses: {{ error.message }}</p>
-      <p class="text-sm text-gray-500 dark:text-gray-400">Ensure the backend is running (port 3001) and accessible.</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400">Ensure the backend is running (port 3002) and accessible.</p>
     </div>
     <div v-else-if="Object.keys(groupedServices).length === 0 && !isLoading" class="text-center py-10">
       <p class="text-lg text-gray-600 dark:text-gray-300">No services configured yet.</p>
@@ -107,7 +107,7 @@ export default {
       this.error = null;
 
       try {
-        const response = await axios.get('http://localhost:3001/api/services/statuses');
+        const response = await axios.get(import.meta.env.VITE_API_BASE_URL + '/services/statuses');
         this.services = response.data; // Keep raw list, computed prop will group and sort
         this.lastUpdated = Date.now();
       } catch (err) {

--- a/frontend/src/store/auth.js
+++ b/frontend/src/store/auth.js
@@ -4,7 +4,7 @@ import router from '../router'; // Import router for navigation
 
 // Axios instance that ensures credentials are sent
 const apiClient = axios.create({
-  baseURL: 'http://localhost:3001/api', // Your backend API base URL
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   withCredentials: true // Important for sessions/cookies
 });
 

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -90,7 +90,7 @@ export default {
 
     // Create an Axios instance for admin actions, ensuring credentials are sent
     const adminApiClient = axios.create({
-        baseURL: 'http://localhost:3001/api', // Backend API base URL
+        baseURL: import.meta.env.VITE_API_BASE_URL,
         withCredentials: true // Important for sessions/cookies
     });
 


### PR DESCRIPTION
This change addresses a port conflict issue by moving the backend service's default host port from 3001 to 3002.

Key changes include:
- Updated `docker-compose.yml` to map host port 3002 to the backend container's port 3001.
- Updated the `VITE_API_BASE_URL` build argument in `docker-compose.yml` for the frontend service to `http://localhost:3002/api`.
- Modified frontend components (`AdminView.vue`, `ServiceList.vue`) and the auth store (`auth.js`) to use `import.meta.env.VITE_API_BASE_URL` for API calls, ensuring they connect to the backend at the new port.
- Updated `README.md` to reflect the new backend API access URL (3002) and to provide clearer instructions for your frontend local development regarding `VITE_API_BASE_URL` configuration.

Additionally, during the testing of this change, some unrelated syntax errors in `backend/index.js` (related to template literals and a catch block) were identified and corrected.